### PR TITLE
add run_exports for downstream pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   run_exports:
     # XZ's track record of backcompat is very good.  Keep default pins (next major version)
     #    https://abi-laboratory.pro/tracker/timeline/xz/
-    - {{ pin_compatible('xz') }}
+    - {{ pin_subpackage('xz') }}
 
 requirements:
   build:


### PR DESCRIPTION
pin_compatible is not the right thing to use here.