### PR TITLE
Update/5.2.10 win mingw

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,3 +19,6 @@ FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
 
+bash -lxc ./bld_win.sh
+if %errorlevel% neq 0 exit /b %errorlevel%
+exit /b 0s

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,6 @@ FOR /F "delims=" %%i IN ('cygpath.exe -u "%BUILD_PREFIX%"') DO set "BUILD_PREFIX
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
-FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,46 +1,21 @@
-@echo on
+copy "%RECIPE_DIR%\bld_win.sh" .
 
-:: Build Static library (.lib)
-cmake -GNinja ^
-      -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-      %COMPILER% ^
-      -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=FALSE ^
-      -DBUILD_SHARED_LIBS=OFF ^
-      -DCMAKE_BUILD_TYPE=Release ^
-      --debug-trycompile ^
-      .
-ninja
-if errorlevel 1 exit /b 1
 
-ninja install
-if errorlevel 1 exit /b 1
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
 
-:: Rename Static library from liblzma.lib to liblzma_static.lib
-:: The next step will build the DLL, which creates an import library
-:: that would share the same name.
-move %LIBRARY_LIB%\liblzma.lib %LIBRARY_LIB%\liblzma_static.lib
+set "saved_recipe_dir=%RECIPE_DIR%"
+echo 1
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%BUILD_PREFIX%"') DO set "BUILD_PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+echo 2
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
 
-:: Build Shared library (.dll)
-cmake -GNinja ^
-      -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-      %COMPILER% ^
-      -DCMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS:BOOL=FALSE ^
-      -DBUILD_SHARED_LIBS=ON ^
-      -DCMAKE_BUILD_TYPE=Release ^
-      --debug-trycompile ^
-      .
-ninja
-if errorlevel 1 exit /b 1
-
-ninja install
-if errorlevel 1 exit /b 1
-
-DEL src\common\inttypes.h
-DEL src\common\stdint.h
-goto common_exit
-
-:common_exit
-cd %SRC_DIR%
-MOVE src\liblzma\api\lzma %LIBRARY_INC%\
-COPY src\liblzma\api\lzma.h %LIBRARY_INC%\
-exit /b 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,11 +7,11 @@ msbuild ^
   /p:AdditionalIncludeDirectories=%LIBRARY_INC% ^
   /p:AdditionalDependencies=/LIBPATH:%LIBRARY_LIB% ^
   /p:WindowsTargetPlatformVersion=10.0.17763.0 ^
-  windows\vs2017\xz_win.sln
+  windows\%c_compiler%\xz_win.sln
 
-COPY windows\vs2017\Release\x64\liblzma\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma_static.lib
-COPY windows\vs2017\Release\x64\liblzma_dll\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma.lib
-COPY windows\vs2017\Release\x64\liblzma_dll\liblzma.dll %LIBRARY_PREFIX%\bin\liblzma.dll
+COPY windows\%c_compiler%\Release\x64\liblzma\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma_static.lib
+COPY windows\%c_compiler%\Release\x64\liblzma_dll\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma.lib
+COPY windows\%c_compiler%\Release\x64\liblzma_dll\liblzma.dll %LIBRARY_PREFIX%\bin\liblzma.dll
 
 @REM Use min-gw to build command line tools
 set MSYSTEM=MINGW%ARCH%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,3 @@
-copy "%RECIPE_DIR%\bld_win.sh" .
-
 @REM Use the MSVC sln to build static lib and dll
 msbuild ^
   /p:Platform=%PLATFORM% ^
@@ -32,6 +30,6 @@ FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
 
-bash -lxc ./bld_win.sh
+bash -lxc %RECIPE_DIR%/bld_win.sh
 if %errorlevel% neq 0 exit /b %errorlevel%
 exit /b 0s

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,19 +1,16 @@
 copy "%RECIPE_DIR%\bld_win.sh" .
 
-
 set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
 
 set "saved_recipe_dir=%RECIPE_DIR%"
-echo 1
 FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%BUILD_PREFIX%"') DO set "BUILD_PREFIX=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
-echo 2
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
 FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,25 @@
 copy "%RECIPE_DIR%\bld_win.sh" .
 
+@REM Use the MSVC sln to build static lib and dll
+msbuild ^
+  /p:Platform=%PLATFORM% ^
+  /p:Configuration=Release ^
+  /p:AdditionalIncludeDirectories=%LIBRARY_INC% ^
+  /p:AdditionalDependencies=/LIBPATH:%LIBRARY_LIB% ^
+  /p:WindowsTargetPlatformVersion=10.0.17763.0 ^
+  windows\vs2017\xz_win.sln
+
+COPY windows\vs2017\Release\x64\liblzma\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma_static.lib
+COPY windows\vs2017\Release\x64\liblzma_dll\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma.lib
+COPY windows\vs2017\Release\x64\liblzma_dll\liblzma.dll %LIBRARY_PREFIX%\bin\liblzma.dll
+
+@REM Use min-gw to build command line tools
 set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
+
+@REM No longer want to use cl.exe
+set CC=
 
 set "saved_recipe_dir=%RECIPE_DIR%"
 FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -39,4 +39,7 @@ make -C tests check
 cp -v src/liblzma/.libs/liblzma-*.dll "$LIBRARY_PREFIX/bin/liblzma.dll"
 cp -v src/liblzma/.libs/liblzma.a "$LIBRARY_PREFIX/lib/liblzma.lib"
 
+mv src/liblzma/api/lzma $LIBRARY_INC
+cp src/liblzma/api/lzma.h $LIBRARY_INC
+
 find $PREFIX -name '*.la' -delete

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $SRC_DIR
+
 export BUILD=x86_64-w64-mingw32
 export HOST=x86_64-w64-mingw32
 # See $SRC_DIR/windows/build.bash for more info.

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+export BUILD=x86_64-w64-mingw32
+export HOST=x86_64-w64-mingw32
+
+./configure \
+      --prefix=${PREFIX} \
+      --enable-silent-rules \
+      --disable-dependency-tracking \
+      --disable-nls \
+      --disable-scripts \
+      --disable-threads \
+      --disable-shared \
+      --enable-small \
+      --build=$BUILD \
+      CFLAGS="-march=x86-64 -mtune=generic -Os"
+
+make -j${CPU_COUNT} ${VERBOSE_AT}
+make check
+make install
+
+cp -v src/liblzma/.libs/liblzma-*.lib "$LIBRARY_PREFIX/bin/liblzma-static.lib"
+
+make distclean
+
+# Build the normal speed-optimized (shared) binaries.
+./configure \
+    --prefix= \
+    --enable-silent-rules \
+    --disable-dependency-tracking \
+    --disable-nls \
+    --disable-scripts \
+    --build="$BUILD" \
+    CFLAGS="-march=x86-64 -mtune=generic -O2"
+make -C src/liblzma
+make -C src/xz LDFLAGS=-static
+make -C tests check
+
+cp -v src/liblzma/.libs/liblzma-*.dll "$LIBRARY_PREFIX/bin/liblzma.dll"

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -19,7 +19,7 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install
 
-cp -v src/liblzma/.libs/liblzma-*.lib "$LIBRARY_PREFIX/bin/liblzma-static.lib"
+cp -v src/liblzma/.libs/liblzma-*.a "$LIBRARY_PREFIX/lib/liblzma-static.lib"
 
 make distclean
 

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -19,26 +19,6 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install
 
-cp -v src/liblzma/.libs/liblzma.a "$LIBRARY_PREFIX/lib/liblzma_static.lib"
-
-make distclean
-
-# Build the normal speed-optimized (shared) binaries.
-./configure \
-    --prefix=${PREFIX} \
-    --enable-silent-rules \
-    --disable-dependency-tracking \
-    --disable-nls \
-    --disable-scripts \
-    --build="$BUILD" \
-    CFLAGS="-march=x86-64 -mtune=generic -O2"
-make -C src/liblzma
-make -C src/xz LDFLAGS=-static
-make -C tests check
-
-cp -v src/liblzma/.libs/liblzma-*.dll "$LIBRARY_PREFIX/bin/liblzma.dll"
-cp -v src/liblzma/.libs/liblzma.a "$LIBRARY_PREFIX/lib/liblzma.lib"
-
 mv src/liblzma/api/lzma $LIBRARY_INC
 cp src/liblzma/api/lzma.h $LIBRARY_INC
 

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -19,7 +19,7 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install
 
-cp -v src/liblzma/.libs/liblzma-*.a "$LIBRARY_PREFIX/lib/liblzma-static.lib"
+cp -v src/liblzma/.libs/liblzma.a "$LIBRARY_PREFIX/lib/liblzma_static.lib"
 
 make distclean
 
@@ -37,3 +37,6 @@ make -C src/xz LDFLAGS=-static
 make -C tests check
 
 cp -v src/liblzma/.libs/liblzma-*.dll "$LIBRARY_PREFIX/bin/liblzma.dll"
+cp -v src/liblzma/.libs/liblzma.a "$LIBRARY_PREFIX/lib/liblzma.lib"
+
+find $PREFIX -name '*.la' -delete

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -2,7 +2,7 @@
 
 export BUILD=x86_64-w64-mingw32
 export HOST=x86_64-w64-mingw32
-
+# See $SRC_DIR/windows/build.bash for more info.
 ./configure \
       --prefix=${PREFIX} \
       --enable-silent-rules \
@@ -25,7 +25,7 @@ make distclean
 
 # Build the normal speed-optimized (shared) binaries.
 ./configure \
-    --prefix= \
+    --prefix=${PREFIX} \
     --enable-silent-rules \
     --disable-dependency-tracking \
     --disable-nls \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://sourceforge.net/projects/lzmautils/files/xz-{{ version }}.tar.bz2
-  sha256: 795ea0494c66d509b052ddc36dc63bd634e59ff2a0f39c16a3b5644dd01d87e6
+  sha256: 01b71df61521d9da698ce3c33148bff06a131628ff037398c09482f3a26e5408
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ about:
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_file: COPYING
   license_family: GPL2
+  license_url: https://git.tukaani.org/?p=xz.git;a=blob;f=COPYING
   summary: Data compression software with high compression ratio
   description: |
     XZ Utils is free general-purpose data compression software with a high

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,10 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    # cmake-no-system to break circular dependency xz -> cmake -> xz
-    - cmake-no-system  # [win]
-    - ninja-base  # [win]
-    - make  # [not win]
+    - {{ compiler('c') }}  # [not win]
+    - m2w64-toolchain      # [win]
+    - posix     # [win]
+    - make      # [not win]
     - automake  # [not win]
     - libtool   # [not win]
     - patch     # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.9" %}
+{% set version = "5.4.0" %}
 
 package:
   name: xz
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://sourceforge.net/projects/lzmautils/files/xz-{{ version }}.tar.bz2
-  sha256: b194507fba3a462a753c553149ccdaa168337bcb7deefddd067ba987c83dfce6
+  sha256: 795ea0494c66d509b052ddc36dc63bd634e59ff2a0f39c16a3b5644dd01d87e6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}  # [not win]
+    - {{ compiler('c') }}
     - m2w64-toolchain      # [win]
     - posix     # [win]
     - make      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,14 +50,12 @@ about:
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_file: COPYING
   license_family: GPL2
-  license_url: https://git.tukaani.org/?p=xz.git;a=blob;f=COPYING
   summary: Data compression software with high compression ratio
   description: |
     XZ Utils is free general-purpose data compression software with a high
     compression ratio. XZ Utils were written for POSIX-like systems, but also
     work on some not-so-POSIX systems.
   doc_url: https://tukaani.org/xz/
-  doc_source_url: https://github.com/xz-mirror/xz/blob/master/README
   dev_url: https://git.tukaani.org/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - xz --help  # [not win]
     - unxz --help  # [not win]
     - lzma --help  # [not win]
-    - xz.exe --help  # [win]
+    - #xz.exe --help  # [win]
     - unxz.exe --help  # [win]
     - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.4.0" %}
+{% set version = "5.2.10" %}
 
 package:
   name: xz
@@ -37,7 +37,7 @@ test:
     - xz --help  # [not win]
     - unxz --help  # [not win]
     - lzma --help  # [not win]
-    - #xz.exe --help  # [win]
+    - xz.exe --help  # [win]
     - unxz.exe --help  # [win]
     - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.8" %}
+{% set version = "5.2.9" %}
 
 package:
   name: xz
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://downloads.sourceforge.net/project/lzmautils/xz-{{ version }}.tar.bz2
-  sha256: 1f8a43d9fcf325d049a31fe4514dc8c44a6d00ce8860d48c4212d1e349d2a3ed
+  sha256: b194507fba3a462a753c553149ccdaa168337bcb7deefddd067ba987c83dfce6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://downloads.sourceforge.net/project/lzmautils/xz-{{ version }}.tar.bz2
+  url: https://sourceforge.net/projects/lzmautils/files/xz-{{ version }}.tar.bz2
   sha256: b194507fba3a462a753c553149ccdaa168337bcb7deefddd067ba987c83dfce6
 
 build:


### PR DESCRIPTION
# xz 5.2.10

jira: https://anaconda.atlassian.net/browse/PKG-855
upstream: https://git.tukaani.org/?p=xz.git;a=tree ([GitHub mirror](https://github.com/xz-mirror/xz/tree/v5.2.10))
[license](https://git.tukaani.org/?p=xz.git;a=blob;f=COPYING;h=20e60d5b2427334e1fec6701e7c5ad0da0bc8a5d;hb=HEAD)
[release notes](https://git.tukaani.org/?p=xz.git;a=blob;f=NEWS;hb=HEAD#l632)

## Changes
- Update download URL
- Bump version and SHA
- Use mingw build flow in favor of CMAKE/Ninja on Windows

## Notes
- [INSTALL](https://github.com/xz-mirror/xz/blob/v5.2.10/INSTALL#L141) indicates that CMAKE/Visual Studio build flows cannot build the command line tools on Windows, despite this seemingly working on previous versions.
- [win] The MSVC toolchain is used to produce the necessary `dll` and `.lib` files we had previously
- [win] mingw is used only to create the command line tools
