### PR TITLE
Rebuild/5.2.10.b1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,8 +7,8 @@ msbuild ^
   /p:WindowsTargetPlatformVersion=10.0.17763.0 ^
   windows\%c_compiler%\xz_win.sln
 
-COPY windows\%c_compiler%\Release\x64\liblzma\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma_static.lib
-COPY windows\%c_compiler%\Release\x64\liblzma_dll\liblzma.lib %LIBRARY_PREFIX%\lib\liblzma.lib
+COPY windows\%c_compiler%\Release\x64\liblzma\liblzma.lib %LIBRARY_LIB%\liblzma_static.lib
+COPY windows\%c_compiler%\Release\x64\liblzma_dll\liblzma.lib %LIBRARY_LIB%\liblzma.lib
 COPY windows\%c_compiler%\Release\x64\liblzma_dll\liblzma.dll %LIBRARY_PREFIX%\bin\liblzma.dll
 
 @REM Use min-gw to build command line tools

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -24,4 +24,8 @@ make install
 mv src/liblzma/api/lzma $LIBRARY_INC
 cp src/liblzma/api/lzma.h $LIBRARY_INC
 
+rm -rf ${PREFIX}/lib
+rm -rf ${PREFIX}/include
+rm -rf ${PREFIX}/share
+
 find $PREFIX -name '*.la' -delete

--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -21,11 +21,16 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 make check
 make install
 
+# Move command-line tools to their windows location.
+mv ${PREFIX}/bin/* $LIBRARY_BIN
+
 mv src/liblzma/api/lzma $LIBRARY_INC
 cp src/liblzma/api/lzma.h $LIBRARY_INC
 
+# Remove posix style directories
 rm -rf ${PREFIX}/lib
 rm -rf ${PREFIX}/include
 rm -rf ${PREFIX}/share
+rm -rf ${PREFIX}/bin
 
 find $PREFIX -name '*.la' -delete

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 01b71df61521d9da698ce3c33148bff06a131628ff037398c09482f3a26e5408
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # XZ's track record of backcompat is very good.  Keep default pins (next major version)
     #    https://abi-laboratory.pro/tracker/timeline/xz/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1  # [win]
+    - if exist %PREFIX%\\lib exit 1 # [win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1  # [win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 


### PR DESCRIPTION
# Rebuild xz 5.2.10 b1

## Changes
- Move `${PREFIX}/bin` files to `${PREFIX}/Library/bin` on Windows
- Cleanup the posix directories created by `make install` on Windows:
    - `${PREFIX}/lib`
    - `${PREFIX}/include`
    - `${PREFIX}/share`
    - `${PREFIX}/bin`
- Add tests for windows:
    - ensure `${PREFIX}/lib` does not exist
    - ensure command line tools are present where expected
- Prefer `%LIBRARY_LIB%` over `%LIBRARY_PREFIX%\lib`

Attempts to address https://github.com/AnacondaRecipes/xz-feedstock/pull/11#issuecomment-1386915492
