### PR TITLE
xz 5.4.6

### DIFF
--- a/recipe/bld_win.sh
+++ b/recipe/bld_win.sh
@@ -27,6 +27,9 @@ mv ${PREFIX}/bin/* $LIBRARY_BIN
 mv src/liblzma/api/lzma $LIBRARY_INC
 cp src/liblzma/api/lzma.h $LIBRARY_INC
 
+[[ -d ${LIBRARY_LIB}/pkgconfig ]] || mkdir ${LIBRARY_LIB}/pkgconfig
+cp src/liblzma/liblzma.pc ${LIBRARY_LIB}/pkgconfig
+
 # Remove posix style directories
 rm -rf ${PREFIX}/lib
 rm -rf ${PREFIX}/include

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.6.0" %}
+{% set version = "5.4.6" %}
 {% set major = version.split('.')[0] %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tukaani-project/xz/releases/download/v{{ version }}/xz-{{ version }}.tar.bz2
-  sha256: 88c8631cefba91664fdc47b14bb753e1876f4964a07db650821d203992b1e1ea
+  sha256: 8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79
 
 build:
   number: 0
@@ -49,7 +49,6 @@ test:
     - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1            # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1            # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1     # [win]
-    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix liblzma`) do if not exist "%%a/liblzma.lib" exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\liblzma.pc exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1             # [win]
     - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1                 # [win]
@@ -59,7 +58,7 @@ test:
 
 about:
   home: https://xz.tukaani.org/xz-utils/
-  license: LGPL-2.1-or-later and GPL-2.0-or-later
+  license: LGPL-2.1-or-later and GPL-2.0-or-later and 0BSD
   license_file: COPYING
   license_family: GPL2
   summary: Data compression software with high compression ratio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ about:
     compression ratio. XZ Utils were written for POSIX-like systems, but also
     work on some not-so-POSIX systems.
   doc_url: https://tukaani.org/xz/
-  dev_url: https://git.tukaani.org/
+  dev_url: https://github.com/tukaani-project/xz
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.4.6" %}
+{% set version = "5.6.0" %}
 {% set major = version.split('.')[0] %}
 
 package:
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://sourceforge.net/projects/lzmautils/files/xz-{{ version }}.tar.bz2
-  sha256: 913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
+  url: https://github.com/tukaani-project/xz/releases/download/v{{ version }}/xz-{{ version }}.tar.bz2
+  sha256: 88c8631cefba91664fdc47b14bb753e1876f4964a07db650821d203992b1e1ea
 
 build:
   number: 0
@@ -39,6 +39,7 @@ test:
     - unxz.exe --help  # [win]
     - test -f ${PREFIX}/include/lzma.h                          # [unix]
     - test -f ${PREFIX}/lib/pkgconfig/liblzma.pc                # [unix]
+    - test -f `pkg-config --variable=libdir --dont-define-prefix liblzma`/liblzma${SHLIB_EXT}  # [unix]
     - test -f ${PREFIX}/lib/liblzma.a                           # [unix]
     - test -f ${PREFIX}/lib/liblzma${SHLIB_EXT}                # [unix]
     - test -f ${PREFIX}/lib/liblzma.{{ major }}${SHLIB_EXT}    # [osx]
@@ -47,6 +48,7 @@ test:
     - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1            # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1            # [win]
     - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1     # [win]
+    - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix liblzma`) do if not exist "%%a/liblzma.lib" exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\liblzma.pc exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1             # [win]
     - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1                 # [win]
@@ -55,7 +57,7 @@ test:
     - conda inspect objects -p $PREFIX $PKG_NAME                         # [osx]
 
 about:
-  home: https://tukaani.org/xz/
+  home: https://xz.tukaani.org/xz-utils/
   license: LGPL-2.1-or-later and GPL-2.0-or-later
   license_file: COPYING
   license_family: GPL2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
   requires:
     # To use 'conda inspect', install conda-build
     - conda-build # [osx]
+    - pkg-config
   commands:
     - xz --help        # [not win]
     - unxz --help      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tukaani-project/xz/releases/download/v{{ version }}/xz-{{ version }}.tar.bz2
-  sha256: 8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79
+  sha256: 913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "5.4.5" %}
+{% set version = "5.4.6" %}
+{% set major = version.split('.')[0] %}
 
 package:
   name: xz
@@ -6,7 +7,7 @@ package:
 
 source:
   url: https://sourceforge.net/projects/lzmautils/files/xz-{{ version }}.tar.bz2
-  sha256: 8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79
+  sha256: 913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
 
 build:
   number: 0
@@ -31,19 +32,27 @@ test:
     # To use 'conda inspect', install conda-build
     - conda-build # [osx]
   commands:
-    - xz --help  # [not win]
-    - unxz --help  # [not win]
-    - lzma --help  # [not win]
-    - xz.exe --help  # [win]
+    - xz --help        # [not win]
+    - unxz --help      # [not win]
+    - lzma --help      # [not win]
+    - xz.exe --help    # [win]
     - unxz.exe --help  # [win]
-    - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1  # [win]
-    - if exist %PREFIX%\\lib exit 1 # [win]
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - test -f ${PREFIX}/include/lzma.h                          # [unix]
+    - test -f ${PREFIX}/lib/pkgconfig/liblzma.pc                # [unix]
+    - test -f ${PREFIX}/lib/liblzma.a                           # [unix]
+    - test -f ${PREFIX}/lib/liblzma${SHLIB_EXT}                # [unix]
+    - test -f ${PREFIX}/lib/liblzma.{{ major }}${SHLIB_EXT}    # [osx]
+    - test -f ${PREFIX}/lib/liblzma${SHLIB_EXT}.{{ major }}    # [linux]
+    - test -f ${PREFIX}/lib/liblzma${SHLIB_EXT}.{{ version }}  # [linux]
+    - if not exist %PREFIX%\\Library\\bin\\liblzma.dll exit 1            # [win]
+    - if not exist %PREFIX%\\Library\\lib\\liblzma.lib exit 1            # [win]
+    - if not exist %PREFIX%\\Library\\lib\\liblzma_static.lib exit 1     # [win]
+    - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\liblzma.pc exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\include\\lzma.h exit 1             # [win]
+    - if not exist %PREFIX%\\Library\\bin\\xz.exe exit 1                 # [win]
+    - if exist %PREFIX%\\lib exit 1                                      # [win]
+    - conda inspect linkages -p $PREFIX $PKG_NAME                        # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME                         # [osx]
 
 about:
   home: https://tukaani.org/xz/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ test:
   requires:
     # To use 'conda inspect', install conda-build
     - conda-build # [osx]
-    - pkg-config
+    - pkg-config  # [unix]
   commands:
     - xz --help        # [not win]
     - unxz --help      # [not win]


### PR DESCRIPTION
xz 5.4.6

**Destination channel:** defaults

### Links

- [PKG-4149](https://anaconda.atlassian.net/browse/PKG-4149) 
- [Upstream repository](https://github.com/tukaani-project/xz/tree/v5.4.6)
- [Upstream changelog/diff](https://github.com/tukaani-project/xz/compare/v5.4.5...v5.4.6)

### Explanation of changes:

- Copy the pkgconfig file `liblzma.pc` on `win`
- Update `source/url` because `WARNING: Error: HTTP 404 NOT FOUND for url <https://sourceforge.net/projects/lzmautils/files/xz-5.6.0.tar.bz2>`
- Add new test commands
- Update home url
- Update dev_url

### Notes

- It was found that `liblzma.pc` file is missing on **win64** but it's required by `r-cairo` package. `r-cairo` has a couple of problems:
  - it really wants a `PKG_CONFIG_PATH` to point to `%LIBRARY_LIB%/pkgconfig` to pick up `cairo`, `libtiff` and `libjpeg` info
  - `libtiff` wants to use `liblzma` (which _MSYS2_ supplies separately as `msys2-liblzma` but is bundled in `xz` in **defaults**) and the defaults package doesn't have a `liblzma.pc `file -- it is created during a build but not obviously copied for install.
- We do not build the latest version **5.6.0** yet because of the significant changes, see https://github.com/tukaani-project/xz/releases/tag/v5.6.0.


[PKG-4149]: https://anaconda.atlassian.net/browse/PKG-4149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ